### PR TITLE
added wp-languages repository and dropin-paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
 			"public/wp-content/themes/{$name}": [ "type:wordpress-theme" ],
 			"public/wp-content/mu-plugins/{$name}": [ "type:wordpress-muplugin" ]
 		},
+    		"dropin-paths": {
+      			"public/wp-content/languages/": [ "vendor:koodimonni-language" ],
+      			"public/wp-content/languages/plugins/": [ "vendor:koodimonni-plugin-language" ],
+			"public/wp-content/languages/themes/": [ "vendor:koodimonni-theme-language" ]
+    		},
 		"wpstarter": {
 			"register-theme-folder": false,
 			"prevent-overwrite": [ ".gitignore" ],
@@ -32,6 +37,10 @@
 		{
 			"type": "composer",
 			"url": "https://wpackagist.org"
-		}
+		},
+		{
+      			"type": "composer",
+			"url": "https://wp-languages.github.io"
+    		}
 	]
 }


### PR DESCRIPTION
added wp-languages to `repository`-list and confiugred `dropin-paths` in `extra` for loading other languages for wordpress via `require` - e.G.:
 
-  `"koodimonni-language/core-de_de": "*",`
- `"koodimonni-theme-language/twentysixteen-de_de": "*"`